### PR TITLE
Fix app_backend_article resource in _main.yaml

### DIFF
--- a/docs/cookbook/entities/configure-your-routes.rst
+++ b/docs/cookbook/entities/configure-your-routes.rst
@@ -33,7 +33,7 @@ And add it on backend routes configuration.
     [...]
 
     app_backend_article:
-        resource: "backend/article.yaml"
+        resource: "article.yaml"
 
 And that’s all!
 


### PR DESCRIPTION
I think the resource from `app_backend_article` in `config/routes/backend/_main.yaml` is wrong. We are already in the folder `backend` so the resource need to be only `"article.yaml"`