### PR TITLE
oauth2 client fixture update to add some default grant_types

### DIFF
--- a/src/Monofony/Plugin/FixturesPlugin/Recipe/config/sylius/fixtures.yaml
+++ b/src/Monofony/Plugin/FixturesPlugin/Recipe/config/sylius/fixtures.yaml
@@ -34,3 +34,4 @@ sylius_fixtures:
                             client:
                                 random_id: 5rbhrb0iiukokcwk8gow0w4ocgww0oco8g8gsgokwc0wcssg4w
                                 secret: 2rlxzhijcx448ow4c0gksw4wo8oo4k8kkwwg0osskk8g0k8kw8
+                                allowed_grant_types: [password, access_token, refresh_token]

--- a/src/Monofony/Plugin/FixturesPlugin/Recipe/src/Fixture/ApiClientFixture.php
+++ b/src/Monofony/Plugin/FixturesPlugin/Recipe/src/Fixture/ApiClientFixture.php
@@ -33,7 +33,6 @@ class ApiClientFixture extends AbstractResourceFixture
             ->children()
                 ->scalarNode('random_id')->cannotBeEmpty()->end()
                 ->scalarNode('secret')->cannotBeEmpty()->end()
-                ->arrayNode('allowed_grant_types')->scalarPrototype()->cannotBeEmpty()->defaultValue([])->end()
-        ;
+                ->arrayNode('allowed_grant_types')->scalarPrototype()->cannotBeEmpty()->defaultValue(['password', 'access_token', 'refresh_token'])->end();
     }
 }

--- a/src/Monofony/Plugin/FixturesPlugin/Recipe/src/Fixture/Factory/ApiClientExampleFactory.php
+++ b/src/Monofony/Plugin/FixturesPlugin/Recipe/src/Fixture/Factory/ApiClientExampleFactory.php
@@ -61,7 +61,7 @@ class ApiClientExampleFactory extends AbstractExampleFactory
             ->setDefault('secret', function (Options $options): string {
                 return $this->faker->uuid;
             })
-            ->setDefault('allowed_grant_types', [])
+            ->setDefault('allowed_grant_types', ['password', 'access_token', 'refresh_token'])
             ->setAllowedTypes('allowed_grant_types', ['array'])
         ;
     }


### PR DESCRIPTION
[F] Default fixtures now include the 'password' grant_type so that API connection is possible via /api/oauth/v2/token endpoint

| Q               | A
| --------------- | -----
| Branch?         | 0.2
| Bug fix?        | yes
| New feature?    | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

<!--
 - Bug fixes must be submitted against the 0.2 branch
 - Features and deprecations must be submitted against the master branch
-->
