### PR TITLE
fix interface method signature

### DIFF
--- a/src/Monofony/Contracts/Api/Identifier/AppUserIdentifierNormalizerInterface.php
+++ b/src/Monofony/Contracts/Api/Identifier/AppUserIdentifierNormalizerInterface.php
@@ -23,10 +23,10 @@ interface AppUserIdentifierNormalizerInterface extends DenormalizerInterface
      * @psalm-suppress InvalidReturnType
      * @psalm-suppress InvalidReturnStatement
      */
-    public function denormalize($data, $type, $format = null, array $context = []);
+    public function denormalize($data, string $type, string $format = null, array $context = []);
 
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, $type, $format = null);
+    public function supportsDenormalization($data, string $type, string $format = null);
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,4 +1,7 @@
 {
+    "aeon-php/calendar": {
+        "version": "0.16.1"
+    },
     "amphp/amp": {
         "version": "v2.1.1"
     },


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 0.5
| Bug fix?        | yes
| New feature?    | no
| Related tickets | #
| License         | MIT

AppUserIdentifierNormalizerInterface does not respect Symfony\Component\Serializer\Normalizer\DenormalizerInterface.  
