### PR TITLE
Change dependency of monofony/customer with sylius/customer

### DIFF
--- a/src/Monofony/Bridge/SyliusUser/composer.json
+++ b/src/Monofony/Bridge/SyliusUser/composer.json
@@ -8,7 +8,7 @@
         "monofony/core-contracts": "^0.10",
         "sylius/user": "^1.12",
         "sylius/user-bundle": "^1.12",
-        "monofony/customer": "^1.10"
+        "sylius/customer": "^1.12"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.5"

--- a/src/Monofony/Contracts/Core/composer.json
+++ b/src/Monofony/Contracts/Core/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "monofony/customer": "^1.10",
+        "sylius/customer": "^1.12",
         "sylius/user": "^1.12"
     },
     "require-dev": {


### PR DESCRIPTION
| Q               | A                                       |
|-----------------|-----------------------------------------|
| Branch?         | 0.11                            |
| Bug fix?        | yes                                  |
| New feature?    | no                                  |
| Related tickets | fixes [92](https://github.com/Monofony/Skeleton/issues/92) | [CoreContracts #1](https://github.com/Monofony/CoreContracts/pull/1) |
| License         | MIT                                     |

 - Bug fixes must be submitted against the 0.10 branch
 - Features and deprecations must be submitted against the 0.11 branch

Is the above statement true ?